### PR TITLE
Add SwiftUI page templates

### DIFF
--- a/dimeloc/AdminView.swift
+++ b/dimeloc/AdminView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct AdminView: View {
+    var body: some View {
+        Text("Admin")
+            .font(.title)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+#Preview {
+    AdminView()
+}

--- a/dimeloc/ContentView.swift
+++ b/dimeloc/ContentView.swift
@@ -1,21 +1,29 @@
-//
-//  ContentView.swift
-//  dimeloc
-//
-//  Created by Maria Martinez on 14/06/25.
-// Test de cambio - maru
-
 import SwiftUI
 
 struct ContentView: View {
+    @State private var showSplash = true
+    @State private var loggedIn = false
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        Group {
+            if showSplash {
+                SplashView()
+                    .transition(.opacity)
+            } else if !loggedIn {
+                LoginView(onLogin: { loggedIn = true })
+                    .transition(.opacity)
+            } else {
+                MainView()
+                    .transition(.opacity)
+            }
         }
-        .padding()
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                withAnimation {
+                    showSplash = false
+                }
+            }
+        }
     }
 }
 

--- a/dimeloc/HomeView.swift
+++ b/dimeloc/HomeView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct HomeView: View {
+    var body: some View {
+        Text("Home")
+            .font(.title)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+#Preview {
+    HomeView()
+}

--- a/dimeloc/LoginView.swift
+++ b/dimeloc/LoginView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct LoginView: View {
+    var onLogin: () -> Void
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Log In")
+                .font(.title)
+                .padding()
+            Button("Go to Home", action: onLogin)
+                .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+#Preview {
+    LoginView(onLogin: {})
+}

--- a/dimeloc/MainView.swift
+++ b/dimeloc/MainView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct MainView: View {
+    enum Tab {
+        case map, home, admin
+    }
+
+    @State private var selectedTab: Tab = .home
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            Group {
+                switch selectedTab {
+                case .home:
+                    HomeView()
+                case .map:
+                    MapView()
+                case .admin:
+                    AdminView()
+                }
+            }
+            BottomNavBar(selectedTab: $selectedTab)
+                .padding(.bottom, 20)
+        }
+    }
+}
+
+struct BottomNavBar: View {
+    @Binding var selectedTab: MainView.Tab
+
+    var body: some View {
+        HStack(spacing: 40) {
+            navButton(icon: "map", tab: .map)
+            navButton(icon: "house", tab: .home)
+            navButton(icon: "chart.bar", tab: .admin)
+        }
+        .padding()
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 25.0, style: .continuous))
+        .shadow(radius: 5)
+    }
+
+    private func navButton(icon: String, tab: MainView.Tab) -> some View {
+        Button(action: { selectedTab = tab }) {
+            Image(systemName: icon + (selectedTab == tab ? ".fill" : ""))
+                .font(.title2)
+                .foregroundColor(selectedTab == tab ? .accentColor : .gray)
+        }
+    }
+}
+
+#Preview {
+    MainView()
+}

--- a/dimeloc/MapView.swift
+++ b/dimeloc/MapView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct MapView: View {
+    var body: some View {
+        Text("Map")
+            .font(.title)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+#Preview {
+    MapView()
+}

--- a/dimeloc/SplashView.swift
+++ b/dimeloc/SplashView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct SplashView: View {
+    var body: some View {
+        Text("Splash")
+            .font(.largeTitle)
+            .bold()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.white)
+    }
+}
+
+#Preview {
+    SplashView()
+}


### PR DESCRIPTION
## Summary
- add SplashView with fade transition
- add LoginView with a button to enter the app
- add HomeView, MapView and AdminView placeholders
- implement MainView with a floating bottom navbar
- update ContentView to manage splash and login flow

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e155d48a083309ec8c01d7544606d